### PR TITLE
Update issue list on new entry

### DIFF
--- a/packages/web/src/components/IssuesList.tsx
+++ b/packages/web/src/components/IssuesList.tsx
@@ -68,8 +68,11 @@ export function IssuesList({ repository, onIssueCreated }: IssuesListProps) {
 
   useEffect(() => {
     if (onIssueCreated) {
-      // Reload issues when a new issue is created
-      loadIssues()
+      // Add a delay to ensure GitHub API has processed the new issue
+      setTimeout(() => {
+        // Reload issues when a new issue is created
+        loadIssues()
+      }, 1500) // 1.5 second delay to give GitHub time to process
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onIssueCreated])

--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -8,7 +8,6 @@ export function HomePage() {
   const location = useLocation()
   const { repositories } = useUserRepositories()
   const [selectedRepository, setSelectedRepository] = useState<string>('')
-  const [refreshTrigger, setRefreshTrigger] = useState(0)
 
   // Check if we have a repository from navigation state
   const repositoryFromState = location.state?.selectedRepository as
@@ -36,8 +35,8 @@ export function HomePage() {
   }, [repositories, repositoryFromState])
 
   const handleIssueCreated = () => {
-    // Trigger a refresh of the issues list
-    setRefreshTrigger((prev) => prev + 1)
+    // Issues list will refresh automatically with a delay
+    // This callback is passed to trigger the refresh in IssuesList
   }
 
   return (
@@ -57,7 +56,6 @@ export function HomePage() {
           <IssuesList
             repository={selectedRepository}
             onIssueCreated={handleIssueCreated}
-            key={refreshTrigger}
           />
         </div>
       </div>


### PR DESCRIPTION
Add a delay to issue list refresh after creation to ensure new issues are displayed.

The issues list was refreshing too quickly after a new issue was created, leading to a race condition where the new issue wasn't yet available from GitHub's API. This required users to manually refresh the list. A 1.5-second delay is now introduced before reloading the issues list, allowing GitHub to process the new issue.