### PR TITLE
Überprüfung und Umsetzung des Refresh-Plans

### DIFF
--- a/packages/web/src/components/IssuesList.tsx
+++ b/packages/web/src/components/IssuesList.tsx
@@ -39,10 +39,10 @@ interface GitHubIssue {
 
 interface IssuesListProps {
   repository: string | null
-  onIssueCreated?: () => void
+  reloadTrigger?: number // New prop to trigger reload
 }
 
-export function IssuesList({ repository, onIssueCreated }: IssuesListProps) {
+export function IssuesList({ repository, reloadTrigger }: IssuesListProps) {
   const { user } = useAuth()
   const [issues, setIssues] = useState<GitHubIssue[]>([])
   const [filteredIssues, setFilteredIssues] = useState<GitHubIssue[]>([])
@@ -66,16 +66,16 @@ export function IssuesList({ repository, onIssueCreated }: IssuesListProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [issues, filter, myIssueNumbers])
 
+  // React to reload trigger changes
   useEffect(() => {
-    if (onIssueCreated) {
+    if (reloadTrigger && reloadTrigger > 0) {
       // Add a delay to ensure GitHub API has processed the new issue
       setTimeout(() => {
-        // Reload issues when a new issue is created
         loadIssues()
       }, 1500) // 1.5 second delay to give GitHub time to process
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onIssueCreated])
+  }, [reloadTrigger])
 
   const loadIssues = async () => {
     if (!repository) return

--- a/packages/web/src/components/VoiceRecorder.tsx
+++ b/packages/web/src/components/VoiceRecorder.tsx
@@ -283,10 +283,9 @@ export function VoiceRecorder({
               setTimeout(() => {
                 setIssueCreationSuccess(false)
                 setCreatedIssueData(null)
+                // Notify parent component that an issue was created (when modal closes)
+                onIssueCreated?.()
               }, 5000)
-
-              // Notify parent component that an issue was created
-              onIssueCreated?.()
 
               // Reset state
               setGeneratedIssue(null)
@@ -511,6 +510,8 @@ export function VoiceRecorder({
                 onClick={() => {
                   setIssueCreationSuccess(false)
                   setCreatedIssueData(null)
+                  // Notify parent component that an issue was created (when modal closes)
+                  onIssueCreated?.()
                 }}
                 className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
               >
@@ -545,6 +546,8 @@ export function VoiceRecorder({
                   onClick={() => {
                     setIssueCreationSuccess(false)
                     setCreatedIssueData(null)
+                    // Notify parent component that an issue was created (when modal closes)
+                    onIssueCreated?.()
                   }}
                   className="flex-1 bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-200 px-4 py-2 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-500 transition-colors"
                 >

--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -8,6 +8,7 @@ export function HomePage() {
   const location = useLocation()
   const { repositories } = useUserRepositories()
   const [selectedRepository, setSelectedRepository] = useState<string>('')
+  const [reloadTrigger, setReloadTrigger] = useState<number>(0)
 
   // Check if we have a repository from navigation state
   const repositoryFromState = location.state?.selectedRepository as
@@ -35,8 +36,8 @@ export function HomePage() {
   }, [repositories, repositoryFromState])
 
   const handleIssueCreated = () => {
-    // Issues list will refresh automatically with a delay
-    // This callback is passed to trigger the refresh in IssuesList
+    // Trigger reload of issues list
+    setReloadTrigger(Date.now())
   }
 
   return (
@@ -55,7 +56,7 @@ export function HomePage() {
         <div className="lg:sticky lg:top-8 lg:h-[calc(100vh-8rem)] lg:self-start">
           <IssuesList
             repository={selectedRepository}
-            onIssueCreated={handleIssueCreated}
+            reloadTrigger={reloadTrigger}
           />
         </div>
       </div>

--- a/page_refresh_fix_implementation.md
+++ b/page_refresh_fix_implementation.md
@@ -1,0 +1,107 @@
+# Page Refresh Fix - Implementierung ✅
+
+## Problem-Beschreibung
+Nach dem letzten Commit wurde ein Feature implementiert, das die Seite nach 1,5 Sekunden neu laden soll wenn ein neues Issue erstellt wird. Dies funktionierte jedoch nicht korrekt:
+
+1. **Ungewollter Refresh auf Homepage**: Die Startseite wurde nach 1,5 Sekunden automatisch neu geladen, obwohl kein Issue erstellt wurde
+2. **Fehlende Funktionalität**: Beim tatsächlichen Erstellen eines Issues wurde die Liste nicht aktualisiert
+
+## Ursachen-Analyse
+Der Fehler lag in der `IssuesList.tsx` Komponente:
+
+```typescript
+useEffect(() => {
+  if (onIssueCreated) {
+    setTimeout(() => {
+      loadIssues()
+    }, 1500)
+  }
+}, [onIssueCreated])
+```
+
+Das Problem war, dass:
+- Der `useEffect` auf `onIssueCreated` als Dependency hörte
+- Diese Funktion wurde in `HomePage.tsx` bei jedem Re-Render neu erstellt
+- Dies führte dazu, dass der setTimeout bei jedem Render ausgelöst wurde
+- Die Homepage wurde dadurch ungewollt nach 1,5 Sekunden neu geladen
+
+## Lösung-Implementierung
+
+### 1. Neues Interface für IssuesList
+```typescript
+interface IssuesListProps {
+  repository: string | null
+  reloadTrigger?: number // Neuer Prop für Reload-Trigger
+}
+```
+
+### 2. Trigger-basierte Reload-Logik
+```typescript
+// React to reload trigger changes
+useEffect(() => {
+  if (reloadTrigger && reloadTrigger > 0) {
+    // Add a delay to ensure GitHub API has processed the new issue
+    setTimeout(() => {
+      loadIssues()
+    }, 1500) // 1.5 second delay to give GitHub time to process
+  }
+}, [reloadTrigger])
+```
+
+### 3. HomePage State Management
+```typescript
+const [reloadTrigger, setReloadTrigger] = useState<number>(0)
+
+const handleIssueCreated = () => {
+  // Trigger reload of issues list
+  setReloadTrigger(Date.now())
+}
+```
+
+### 4. Success Modal Integration
+Das Callback wird nun beim Schließen des Success-Modals ausgelöst:
+
+```typescript
+// Auto-hide modal after 5 seconds
+setTimeout(() => {
+  setIssueCreationSuccess(false)
+  setCreatedIssueData(null)
+  // Notify parent component that an issue was created (when modal closes)
+  onIssueCreated?.()
+}, 5000)
+```
+
+## Verbesserungen
+
+### ✅ Probleme behoben:
+1. **Kein ungewollter Refresh**: Die Homepage wird nicht mehr automatisch neu geladen
+2. **Korrekte Funktionalität**: Die Issue-Liste wird nur noch aktualisiert, wenn tatsächlich ein Issue erstellt wurde
+3. **Bessere UX**: Das Reload passiert nach dem Schließen des Success-Modals
+
+### ✅ Verhalten nach der Implementierung:
+1. **Startseite**: Kein automatischer Refresh nach 1,5 Sekunden
+2. **Issue-Erstellung**: 
+   - Success-Modal wird angezeigt
+   - Modal schließt sich nach 5 Sekunden (oder manuell)
+   - Beim Schließen wird die Issue-Liste mit 1,5 Sekunden Verzögerung aktualisiert
+3. **GitHub API**: Die 1,5 Sekunden Verzögerung gibt der GitHub API genügend Zeit, das neue Issue zu verarbeiten
+
+## Technische Details
+
+### Geänderte Dateien:
+- `packages/web/src/components/IssuesList.tsx`: Interface und Reload-Logik geändert
+- `packages/web/src/pages/HomePage.tsx`: State Management für Reload-Trigger
+- `packages/web/src/components/VoiceRecorder.tsx`: Callback-Aufruf beim Modal-Schließen
+
+### Build-Status:
+✅ TypeScript-Kompilierung erfolgreich
+✅ Vite-Build erfolgreich
+✅ Alle Linter-Fehler behoben
+
+## Ergebnis
+Das Feature funktioniert nun wie gewünscht:
+- **Kein ungewollter Refresh** auf der Homepage
+- **Korrekte Issue-Listen-Aktualisierung** nach dem Erstellen eines Issues
+- **Bessere User Experience** durch gezielte Aktualisierung nur wenn nötig
+
+**Status: KOMPLETT IMPLEMENTIERT ✅**


### PR DESCRIPTION
Fixes incorrect page refresh behavior and ensures issue list updates after creation.

Previously, the homepage refreshed unintentionally due to a `useEffect` listening to a constantly changing function reference. This PR introduces a trigger-based system to refresh the issue list only when a new issue is successfully created and its success modal closes, preventing unwanted refreshes and ensuring data consistency.