### PR TITLE
Fix button to show issue details

### DIFF
--- a/issue_modal_button_fix.md
+++ b/issue_modal_button_fix.md
@@ -1,0 +1,57 @@
+# Issue Modal Button Fix
+
+## Problem
+Nach der Erstellung eines Issues öffnete der "View Issue" Button im Success-Modal die GitHub-Seite direkt anstatt die Issue-Detailseite in der eigenen Anwendung zu zeigen.
+
+## Solution
+Der Button wurde so geändert, dass er zur internen Issue-Detailseite navigiert.
+
+## Changes Made
+
+### 1. Added Navigation Hook
+- Importiert `useNavigate` von `react-router-dom`
+- Hinzugefügt in der `VoiceRecorder` Komponente
+
+### 2. Modified Button Behavior
+**Before:**
+```javascript
+onClick={() => {
+  window.open(createdIssueData.url, '_blank')
+}}
+```
+
+**After:**
+```javascript
+onClick={() => {
+  // Parse repository to get owner and repo
+  const [owner, repo] = createdIssueData.repository.split('/')
+  if (owner && repo) {
+    // Navigate to internal issue detail page
+    navigate(`/issue/${owner}/${repo}/${createdIssueData.number}`)
+  }
+}}
+```
+
+### 3. Updated Icon
+- Changed from `ExternalLink` to `Eye` icon
+- More appropriate since we're not opening an external link anymore
+
+## Route Structure
+The internal route follows this pattern:
+```
+/issue/:owner/:repo/:issueNumber
+```
+
+Example: `/issue/shortcutchris/077-cdb/123`
+
+## Benefits
+✅ Keeps user within the application
+✅ Maintains application state and context
+✅ Consistent user experience
+✅ No external redirect to GitHub
+
+## Testing
+- Create a new issue via voice recording
+- Wait for the success modal to appear
+- Click "View Issue" button
+- Should navigate to the internal issue detail page instead of opening GitHub

--- a/packages/web/src/components/VoiceRecorder.tsx
+++ b/packages/web/src/components/VoiceRecorder.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
 import {
   Mic,
   Pause,
@@ -8,7 +9,7 @@ import {
   GitBranch,
   AlertCircle,
   CheckCircle2,
-  ExternalLink,
+  Eye,
   X,
 } from 'lucide-react'
 import { useAudioRecorder } from '@/hooks/useAudioRecorder'
@@ -42,6 +43,7 @@ export function VoiceRecorder({
 }: VoiceRecorderProps) {
   const { user } = useAuth()
   const { repositories, loading: reposLoading } = useUserRepositories()
+  const navigate = useNavigate()
   const {
     recordingState,
     startRecording,
@@ -535,11 +537,16 @@ export function VoiceRecorder({
               <div className="flex space-x-3">
                 <button
                   onClick={() => {
-                    window.open(createdIssueData.url, '_blank')
+                    // Parse repository to get owner and repo
+                    const [owner, repo] = createdIssueData.repository.split('/')
+                    if (owner && repo) {
+                      // Navigate to internal issue detail page
+                      navigate(`/issue/${owner}/${repo}/${createdIssueData.number}`)
+                    }
                   }}
                   className="flex-1 flex items-center justify-center space-x-2 bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors"
                 >
-                  <ExternalLink className="h-4 w-4" />
+                  <Eye className="h-4 w-4" />
                   <span>View Issue</span>
                 </button>
                 <button


### PR DESCRIPTION
Change 'View Issue' button in success modal to navigate to internal app page instead of opening GitHub.

Previously, the button opened the GitHub page directly, which disrupted the user's flow within the application. This change ensures users remain within the app, providing a more consistent and integrated experience.